### PR TITLE
Make the dataset dictionary unique per instance

### DIFF
--- a/src/jsontas/data_structures/expand.py
+++ b/src/jsontas/data_structures/expand.py
@@ -94,14 +94,14 @@ class Expand(DataStructure):
         # pylint:disable=cyclic-import
         # pylint:disable=import-outside-toplevel
         from jsontas.jsontas import JsonTas
-        jsontas = JsonTas()
+        jsontas = JsonTas(self.dataset)
         query_tree = self.dataset.get("query_tree")
         amount = self.data.get("to", 0)
 
         evaluated = []
         for index in range(amount):
             value = deepcopy(query_tree.get("value"))
-            jsontas.dataset.add("expand_index", index)
-            jsontas.dataset.add("expand_value", value)
+            self.dataset.add("expand_index", index)
+            self.dataset.add("expand_value", value)
             evaluated.append(jsontas.resolve(json_data=value))
         return None, evaluated

--- a/src/jsontas/data_structures/wait.py
+++ b/src/jsontas/data_structures/wait.py
@@ -124,7 +124,7 @@ class Wait(DataStructure):
         # pylint:disable=cyclic-import
         # pylint:disable=import-outside-toplevel
         from jsontas.jsontas import JsonTas
-        jsontas = JsonTas()
+        jsontas = JsonTas(self.dataset)
         value = None
         query_tree = self.dataset.get("query_tree")
         for value in self.wait(jsontas.resolve,

--- a/src/jsontas/dataset.py
+++ b/src/jsontas/dataset.py
@@ -26,19 +26,21 @@ class Dataset:
     """JSONTas dataset object. Used for lookup of $ notated strings in a JSON file."""
 
     logger = logging.getLogger("Dataset")
-
-    __dataset = {
-        "condition": Condition,
-        "operator": Operator,
-        "list": List,
-        "request": Request,
-        "filter": Filter,
-        "expand": Expand,
-        "from": From,
-        "wait": Wait,
-    }
     # Split value into words separated by anything except ','
     regex = re.compile(r"[\$\-\w!,:]+")
+
+    def __init__(self):
+        """Create an initial dataset of the data structures."""
+        self.__dataset = {
+            "condition": Condition,
+            "operator": Operator,
+            "list": List,
+            "request": Request,
+            "filter": Filter,
+            "expand": Expand,
+            "from": From,
+            "wait": Wait,
+        }
 
     def add(self, key, value):
         """Add a new dataset value and key.

--- a/src/jsontas/jsontas.py
+++ b/src/jsontas/jsontas.py
@@ -26,9 +26,16 @@ class JsonTas:
 
     logger = logging.getLogger("JSONTas")
 
-    def __init__(self):
-        """Initialize dataset."""
-        self.dataset = Dataset()
+    def __init__(self, dataset=None):
+        """Initialize dataset.
+
+        :param dataset: In order to provide a custom dataset class.
+        :type dataset: :obj:`jsontas.dataset.Dataset`
+        """
+        if dataset is not None:
+            self.dataset = dataset
+        else:
+            self.dataset = Dataset()
 
     @staticmethod
     def __get_key(key, dictionary):


### PR DESCRIPTION
The dataset was defined on class level and thus shared between
instances. This could cause problems when running threaded applications
Also added the dataset input argument to JsonTas so that the data
structures that uses JsonTas to evaluate their query_tree can provide
the correct dataset to their instance.

fixes: #10 