### PR TITLE
set minimum Python version to 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,12 @@ authors = [
 ]
 license = "Apache-2.0"
 readme = "README.rst"
-requires-python = ">=3.13"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.9",
 ]
 dependencies = [
     "requests"


### PR DESCRIPTION
### Describe your changes

This change reverts minimum Python version in `pyproject.toml` to 3.9 to keep backwards compatibility.

### Issue ticket number and link

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
